### PR TITLE
Update ManagedMappingObject.m

### DIFF
--- a/src/ManagedMappingObject.m
+++ b/src/ManagedMappingObject.m
@@ -46,7 +46,7 @@
             NSValueTransformer *transformer = [NSValueTransformer valueTransformerForName:transformerName];
             dictionaryValue = [transformer transformedValue:dictionaryValue];
         }
-        if (dictionaryValue != nil) {
+        if (dictionaryValue != nil && dictionaryValue != [NSNull null]) {
             [managedObject setValue:dictionaryValue forKeyPath:objectKey];
         }
     }


### PR DESCRIPTION
NSDictionaryの値が[NSNull null]が含まれていた場合落ちる。ValueTransformer一つづつ定義しても回避できる。
